### PR TITLE
Document deployment verification DNS failure (2025-09-27)

### DIFF
--- a/analysis/deployment-verification-2025-09-27.md
+++ b/analysis/deployment-verification-2025-09-27.md
@@ -1,0 +1,25 @@
+# Dryvest Deployment Verification (2025-09-27)
+
+## Objective
+Confirm the production Cloudflare Pages deployment at `https://dryvest.pages.dev` reflects commit `d435087` and that recently landed features (contact intake + fact-check exports) behave as expected.
+
+## Environment
+- Runner: GitHub Codespaces-style container
+- Tools: `curl`, `ping`
+- Network egress: Restricted DNS resolution for `*.pages.dev`
+
+## Findings
+1. **DNS Resolution Failure**
+   - `curl` and `ping` requests to `dryvest.pages.dev` failed with `DNS resolution failure`, preventing retrieval of the SPA bundle or API responses. 【b03aab†L1-L7】【c68ea9†L1-L3】
+   - Because the hostname could not be resolved, no browser-based tests (disclaimer gate, mode switching, export downloads, contact form submission, or analytics checks) could be executed from this environment.
+
+2. **Partial HEAD Attempt**
+   - A preliminary `curl -I` request returned mixed `200`/`503` headers, suggesting intermediary network handling before the DNS error surfaced. 【f7bd3e†L1-L9】 Further attempts to follow redirects resulted in the DNS failure above.
+
+## Next Steps
+- Re-run the verification from a network with working DNS for `*.pages.dev` (e.g., local workstation or CI runner with outbound DNS).
+- Once connectivity is available, execute the manual checklist provided in the task (disclaimer gate, Fact Check exports, Quick Brief rail, contact form success/failure paths, analytics beacons).
+- Capture browser console/network logs during the session to document the `/api/contact` 204 response and analytics beacon payloads.
+
+## Status
+**Blocked** – Unable to validate deployment due to DNS resolution issues within the current environment.


### PR DESCRIPTION
## Summary
- add a deployment verification log detailing the inability to reach https://dryvest.pages.dev from the current environment
- document the DNS resolution failure encountered while attempting to run the manual QA checklist

## Testing
- curl -I https://dryvest.pages.dev
- curl https://dryvest.pages.dev -L -o /tmp/dryvest.html
- ping -c 1 dryvest.pages.dev

------
https://chatgpt.com/codex/tasks/task_e_68d85cf42dd08323922849382de63d0f